### PR TITLE
웨이브 API 오류 대응 및 셀러리 작업에 프록시 적용

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -111,12 +111,40 @@ from .site_uncensored.site_heyzo import SiteHeyzo
 import functools
 from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 import re
-import json
 import traceback
 import sys
 from unittest.mock import patch
+import datetime
+
+import redis
+
+from framework.init_main import Framework
 
 from .setup import P as PLUGIN
+
+FRAMEWORK = Framework.get_instance()
+LIST_LIMIT = 10
+RECENT_DAYS = 7
+DEFAULT_QUERY = {
+    'limit': 10,
+    'offset': 0,
+    'orderby': 'new',
+    'apikey': 'E5F3E0D30947AA5440556471321BB6D9',
+    'client_version': '6.0.1',
+    'device': 'pc',
+    'drm': 'wm',
+    'partner': 'pooq',
+    'pooqzone': 'none',
+    'region': 'kor',
+    'targetage': 'all',
+}
+DEFAULT_HEADERS = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36 Edg/115.0.1901.20',
+    'Wavve-Credential': PLUGIN.ModelSetting.get('site_wavve_credential'),
+}
+REDIS_CONN = redis.Redis(host='localhost', port=6379, decode_responses=True)
+REDIS_KEY_WAVVE_BLACKLIST_CONTENTS = 'flaskfarm:wavve:blacklist:contents'
+REDIS_CONN.delete(REDIS_KEY_WAVVE_BLACKLIST_CONTENTS)
 
 
 def get_filename_warpper(f):
@@ -181,32 +209,39 @@ def get_prefer_url(url: str) -> str:
 SupportWavve.get_prefer_url = get_prefer_url
 
 
-default_query = {
-    'limit': 10,
-    'offset': 0,
-    'orderby': 'new',
-    'apikey': 'E5F3E0D30947AA5440556471321BB6D9',
-    'client_version': '6.0.1',
-    'device': 'pc',
-    'drm': 'wm',
-    'partner': 'pooq',
-    'pooqzone': 'none',
-    'region': 'kor',
-    'targetage': 'all',
-}
-default_headers = {
-    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36 Edg/115.0.1901.20',
-    'Wavve-Credential': PLUGIN.ModelSetting.get('site_wavve_credential'),
-}
+def vod_programs_landing(query: dict) -> dict:
+    url = urlunparse(('https', 'apis.wavve.com', '/fz/vod/programs/landing', '', urlencode(query, doseq=True), ''))
+    return SupportWavve.session.request('GET', url, headers=DEFAULT_HEADERS).json()
+
+
+def vod_contents_detail(content_id: str, query: dict) -> dict:
+    url = urlunparse(('https', 'apis.wavve.com', f'/fz/vod/contents-detail/{content_id}', '', urlencode(query, doseq=True), ''))
+    return SupportWavve.session.request('GET', url, headers=DEFAULT_HEADERS).json()
+
+
+def vod_newcontents(query: dict) -> dict:
+    url = urlunparse(('https', 'apis.wavve.com', '/cf/vod/newcontents', '', urlencode(query, doseq=True), ''))
+    return SupportWavve.session.request('GET', url, headers=DEFAULT_HEADERS).json()
+
+def vod_programs_contents(program_id: str, query: dict) -> dict:
+    url = urlunparse(('https', 'apis.wavve.com', f'/fz/vod/programs/{program_id}/contents', '', urlencode(query, doseq=True), ''))
+    return SupportWavve.session.request('GET', url, headers=DEFAULT_HEADERS).json()
+
+
+def search_list(keyword: str, query: dict) -> dict:
+    query['keyword'] = keyword
+    url = urlunparse(('https', 'apis.wavve.com', f'/fz/search/list.js', '', urlencode(query, doseq=True), ''))
+    return SupportWavve.session.request('GET', url, headers=DEFAULT_HEADERS).json()
+
+
 def vod_program_contents_programid(code: str, page: int = 1) -> dict:
     '''
     프로그램 정보 api 오류 대응
     '''
-    default_query['offset'] = (page - 1) * 10
-    url = urlunparse(('https', 'apis.wavve.com', f'fz/vod/programs/{code}/contents', '', urlencode(default_query, doseq=True), ''))
     try:
-        response = SupportWavve.session.get(url, headers=default_headers)
-        data = json.loads(response.text)
+        query = dict(DEFAULT_QUERY)
+        query['offset'] = (page - 1) * 10
+        data = vod_programs_contents(code, query)
         data = data.pop('cell_toplist')
         data['list'] = data['celllist']
         for ep in data['list']:
@@ -217,7 +252,6 @@ def vod_program_contents_programid(code: str, page: int = 1) -> dict:
         return data
     except:
         PLUGIN.logger.error(traceback.format_exc())
-        PLUGIN.logger.debug(response.text)
         return {}
 SupportWavve.vod_program_contents_programid = vod_program_contents_programid
 
@@ -292,35 +326,188 @@ def wrapper_vod_programs_programid(f: callable) -> callable:
         data = f(*args, **kwds)
         if not data:
             try:
-                query = dict(default_query)
+                query = dict(DEFAULT_QUERY)
                 query.pop('limit')
                 query.pop('offset')
                 query['programid'] = args[0]
                 query['history'] = 'season'
-                landing_url = urlunparse(('https', 'apis.wavve.com', '/fz/vod/programs/landing', '', urlencode(query, doseq=True), ''))
-                response = SupportWavve.session.request('GET', landing_url, headers=default_headers)
-                landing_data = json.loads(response.text)
-                detail_path = landing_data.get('landing_list', {}).get('path', f'/fz/vod/contents-detail/{landing_data["content_id"]}')
-                detail_url = urlunparse(('https', 'apis.wavve.com', detail_path, '', urlencode(default_query, doseq=True), ''))
-                response = SupportWavve.session.request('GET', detail_url, headers=default_headers)
-                data = json.loads(response.text)
-                data['programtitle'] = data.get('seasontitle') or data.get('programtitle')
-                data['programactors'] = data.pop('season_actors', data.pop('actors', {}))
-                data['cirlceimage'] = data.pop('seasontitlelogoimage', data.pop('programtitlelogoimage', None))
-                data['posterimage'] = data.pop('seasonposterimage', None)
-                data['image'] = data.pop('programimage', data.pop('episodeimage', None))
-                data['livechannelid'] = data.pop('livechannel', None)
-                data['endtime'] = data.pop('programendtime', None)
-                data['starttime'] = data.pop('programstarttime', None)
-                data['cpname'] = data.pop('channelname', None)
-                data['channelname'] = data['cpname']
-                data['livechannelid'] = data.pop('channelid', None)
-                data['playtimetext'] = data.pop('playtime', None)
-                data['closedate'] = None
-                data['onair'] = None
+                content_id = vod_programs_landing(query).get('content_id')
+                contents = SupportWavve.vod_contents_contentid(content_id)
+                data['tags'] = contents.get('tags', {})
+                data['programactors'] = contents.get('actors', {})
+                data['image'] = contents.get('image', contents.get('programimage', ''))
+                data['cirlceimage'] = contents.get('programcircleimage', '')
+                data['posterimage'] = contents.get('programposterimage', '')
+                data['programsynopsis'] = contents.get('programsynopsis', '')
+                data['closedate'] = contents.get('closedate', '')
+                data['onair'] = contents.get('onair', '')
+                data['cpid'] = contents.get('cpid', '')
+                data['endtime'] = contents.get('programendtime', '')
+                data['releaseweekday'] = contents.get('releaseweekday', '')
+                data['starttime'] = contents.get('programstarttime', '')
+                data['channelname'] = contents['channelname']
+                data['programtitle'] = contents.get('seasontitle') or contents.get('programtitle')
+                data['cpname'] = contents.pop('cpname', '')
+                data['livechannelid'] = contents.pop('channelid', '')
+                data['alarm'] = contents.get('alarm', '')
+                data['zzim'] = contents.get('zzim', '')
+                data['programid'] = contents.get('programid', '')
+                data['channelid'] = contents.get('channelid', '')
+                data['firstreleasedate'] = contents.get('firstreleasedate', '')
+                data['playtimetext'] = contents.get('playtimetext', '')
             except Exception as e:
                 PLUGIN.logger.error(e)
                 PLUGIN.logger.error(traceback.format_exc())
         return data
     return wrap
 SupportWavve.vod_programs_programid = wrapper_vod_programs_programid(SupportWavve.vod_programs_programid)
+
+
+def get_vod_ids(celllist: list) -> set:
+    contents_ids = set()
+    for vod in celllist:
+        try:
+            _id = parse_qs(vod['event_list'][1]['url'].split('?')[1]).get('contentid')[0]
+            contents_ids.add(_id)
+            #PLUGIN.logger.debug(f"{vod['alt']} - {_id}")
+        except Exception as e:
+            PLUGIN.logger.error(e)
+            PLUGIN.logger.error(traceback.format_exc())
+            continue
+    return contents_ids
+
+
+def get_vod_ids_from_newcontents(page: int) -> set:
+    '''
+    새로운 API 에서 content id 수집
+    '''
+    query = dict(DEFAULT_QUERY)
+    query['subgenre'] = 'all'
+    query['channel'] = 'all'
+    query['weekday'] = 'all'
+    query['genre'] = 'all'
+    query['limit'] = LIST_LIMIT
+    query['offset'] = (page - 1) * LIST_LIMIT
+    try:
+        celllist = vod_newcontents(query).get('cell_toplist', {}).get('celllist', [])
+        return get_vod_ids(celllist)
+    except Exception as e:
+        PLUGIN.logger.error(e)
+        PLUGIN.logger.error(traceback.format_exc())
+        return set()
+
+
+def get_vod_ids_from_search(keyword: str, page: int) -> set:
+    '''
+    검색 키워드에서 content ID 수집
+    '''
+    query = dict(DEFAULT_QUERY)
+    query['limit'] = LIST_LIMIT
+    query['offset'] = (page - 1) * LIST_LIMIT
+    query['type'] = 'vod'
+    query['version'] = '2'
+    query['mtype'] = ''
+    try:
+        celllist = search_list(keyword, query).get('cell_toplist', {}).get('celllist', [])
+        return get_vod_ids(celllist)
+    except Exception as e:
+        PLUGIN.logger.error(e)
+        PLUGIN.logger.error(traceback.format_exc())
+        return set()
+
+
+def wrapper_vod_newcontents(f: callable) -> callable:
+    @functools.wraps(f)
+    def wrap(*args, **kwds):
+        '''
+        기존 최신 콘텐츠 API 목록에 다른 API에서 가져온 콘텐츠를 추가
+        wavve 플러그인 mod_recent.ModuleRecent.scheduler_function() 이 암호화 되어 있어서 여기서 작업
+            - scheduler_function() 은 wavve.SupportWavve.vod_newcontents() 을 호출함.
+            - api 중복 조회를 감안해야 함.
+
+        "최신"의 기준을 지난 1주일로 상정하고 방송 일자 정보가 없거나 오래된 방송은 제외:
+            - 제외된 content_id는 redis에 저장되고 플러그인 재시작시 삭제됨
+        '''
+        wavve = FRAMEWORK.PluginManager.get_plugin_instance('wavve')
+        recent_quality = wavve.ModelSetting.get('recent_quality')
+        model = wavve.logic.get_module('recent').web_list_model
+        # 기존의 SupportWavve.vod_newcontents() 에서 return 할 데이터
+        data: dict = f(*args, **kwds)
+        page = kwds.get('page', 1)
+        recents = data.get('list', [])
+        recents_ids = {epi['contentid'] for epi in recents}
+        more_recents = set()
+
+        PLUGIN.logger.debug(f'current page: {kwds.get("page", -1)}')
+
+        more_newcontents = get_vod_ids_from_newcontents(page)
+        PLUGIN.logger.debug(f'newcontents: {len(more_newcontents - recents_ids)} more items')
+        more_recents.update(more_newcontents)
+
+        for keyword in ['드라마', '예능', '시사', '교양', '시리즈', '애니메이션', '스포츠']:
+            ids = get_vod_ids_from_search(keyword, page)
+            PLUGIN.logger.debug(f'{keyword}: {len(ids - (recents_ids | more_recents))} more items')
+            more_recents.update(ids)
+
+        PLUGIN.logger.debug(f'more_recents: before={len(more_recents)} after={len(more_recents - recents_ids)}')
+        more_recents.difference_update(recents_ids)
+        if more_recents:
+            PLUGIN.logger.debug(f'found more vods: {len(more_recents)}')
+            date_limit = datetime.datetime.today() - datetime.timedelta(days=RECENT_DAYS)
+            for contentid in more_recents:
+                try:
+                    blacklist = REDIS_CONN.lrange(REDIS_KEY_WAVVE_BLACKLIST_CONTENTS, 0, REDIS_CONN.llen(REDIS_KEY_WAVVE_BLACKLIST_CONTENTS))
+                    if contentid in blacklist:
+                        continue
+                    if model.get_episode_by_recent(contentid):
+                        continue
+                    contents = SupportWavve.vod_contents_contentid(contentid)
+                    programtitle = contents.get('seasontitle') or contents.get('programtitle')
+                    episodenumber = contents.get('episodenumber', -1)
+                    releasedate = contents.get('releasedate', '')
+                    content_type = contents.get('type', '')
+                    # 방송일자 형식이 1900-01-01 이 아니거나 오래됐으면 건너뛰기
+                    try:
+                        rel_date = datetime.datetime.strptime(releasedate, '%Y-%m-%d')
+                        if rel_date < date_limit or \
+                        rel_date - datetime.timedelta(days=1) > datetime.datetime.today():
+                            REDIS_CONN.rpush(REDIS_KEY_WAVVE_BLACKLIST_CONTENTS, contentid)
+                            continue
+                    except Exception as e:
+                        PLUGIN.logger.warning(f'{contentid} - releasedate={releasedate}')
+                        REDIS_CONN.rpush(REDIS_KEY_WAVVE_BLACKLIST_CONTENTS, contentid)
+                        continue
+
+                    PLUGIN.logger.debug(f'add [{programtitle}] [{episodenumber}] [{releasedate}]')
+                    info = {
+                        'episodenumber': episodenumber,
+                        'image': contents.get('image') or contents.get('programimage', ''),
+                        'programtitle': programtitle,
+                        'price': contents.get('price', -1),
+                        'contentid': contentid,
+                        'releasedate': releasedate,
+                        'releaseweekday': contents.get('releaseweekday', ''),
+                        'channelname': contents.get('channelname', ''),
+                        'type': content_type,
+                        'episodetitle': contents.get('episodetitle', ''),
+                        'targetage': contents.get('targetage', 0),
+                        'programid': contents.get('programid', ''),
+                        'update': contents.get('update', '')
+                    }
+                    '''
+                    # API 중복 조회를 회피하기 위해 직접 DB에 저장해 봤지만
+                    # scheduler_function()에서 필터링 처리가 안 되는 상황이 발생
+                    streaming = SupportWavve.streaming(content_type, contentid, recent_quality)
+                    new_item = model('recent', info=info, streaming=streaming, contents=contents)
+                    new_item.set_info(info)
+                    new_item.set_streaming(streaming)
+                    new_item.save()
+                    '''
+                    recents.append(info)
+                except Exception as e:
+                    PLUGIN.logger.warning(e)
+                    PLUGIN.logger.warning(traceback.format_exc())
+                    continue
+        return data
+    return wrap
+SupportWavve.vod_newcontents = wrapper_vod_newcontents(SupportWavve.vod_newcontents)

--- a/mod_site.py
+++ b/mod_site.py
@@ -80,6 +80,12 @@ class ModuleSite(PluginModuleBase):
         self.__tving_init()
         self.__naver_init()
 
+    def plugin_load_celery(self):
+        '''
+        셀러리로 플러그인 로딩시 사이트 정보 초기화
+        '''
+        self.plugin_load()
+
     def __wavve_init(self):
         from . import SupportWavve
         SupportWavve.initialize(


### PR DESCRIPTION
1. 웨이브 API 오류 대응

웨이브 `악인취재기`의 경우 `/vod/programs` API로 데이터를 가져올 수 없어서 플렉스 메타에 적용이 되지 않는 현상이 있습니다.

```json
{
    "resultcode": "550",
    "resultmessage": "해당 데이터가 없습니다."
}
```
```
[2023-09-29 14:56:18,476|ERROR|site_wavve.py:169] Exception:'NoneType' object is not subscriptable
[2023-09-29 14:56:18,477|ERROR|site_wavve.py:170] Traceback (most recent call last):
  File "/home/data/plugins-dev/support_site/site_wavve.py", line 149, in info
    show.title = program_info['programtitle']
TypeError: 'NoneType' object is not subscriptable
```

`vod_programs_programid()`이 `/fz/vod/contents-detail` API를 보조로 사용하도록 변경했습니다.

2. 셀러리 작업에 프록시 적용

셀러리로 플러그인 로딩시 사이트 프록시 정보가 초기화 되지 않아 `plugin_load_celery()`를 추가했습니다.